### PR TITLE
fix freeze on removing module

### DIFF
--- a/apci_dev.c
+++ b/apci_dev.c
@@ -903,7 +903,7 @@ apci_class_dev_register( struct apci_my_info *ddata )
     struct apci_lookup_table_entry *obj = &apci_driver_table[ APCI_LOOKUP_ENTRY( (int)ddata->id->device ) ];
     apci_devel("entering apci_class_dev_register\n");
 
-    ddata->dev = device_create(class_apci, &ddata->pci_dev->dev , apci_first_dev + dev_counter, NULL, "apci/%s_%d", obj->name, obj->counter ++ );
+    ddata->dev = device_create(class_apci, &ddata->pci_dev->dev , apci_first_dev + dev_counter, NULL, "apci/%s_%d", obj->name, obj->counter);
 
     /* add pointer to the list of all ACCES I/O products */
 
@@ -913,6 +913,7 @@ apci_class_dev_register( struct apci_my_info *ddata )
       ddata->dev = NULL;
       return ret;
     }
+    obj->counter ++;
     dev_counter ++;
     apci_devel("leaving apci_class_dev_register\n");
     return 0;

--- a/apci_dev.c
+++ b/apci_dev.c
@@ -113,7 +113,7 @@ static struct pci_device_id ids[] = {
         { PCI_DEVICE(A_VENDOR_ID, mPCIe_AI12_16A ), },
         { PCI_DEVICE(A_VENDOR_ID, mPCIe_AI12_16 ), },
         { PCI_DEVICE(A_VENDOR_ID, mPCIe_AI12_16E ), },
-        { PCI_DEVICE(A_VENDOR_ID, mPCIe_AIO16_16F_proto ) },
+        { PCI_DEVICE(A_VENDOR_ID, mPCIe_AIO16_16F_proto ), },
         { PCI_DEVICE(A_VENDOR_ID, mPCIe_AIO16_16A_proto ), },
         { PCI_DEVICE(A_VENDOR_ID, mPCIe_AIO16_16E_proto ), },
         { PCI_DEVICE(A_VENDOR_ID, mPCIe_AI16_16F_proto ), },
@@ -602,6 +602,8 @@ apci_alloc_driver(struct pci_dev *pdev, const struct pci_device_id *id )
               ddata->regions[0].start   = pci_resource_start(pdev, 0);
               ddata->regions[0].end     = pci_resource_end(pdev, 0);
               ddata->regions[0].flags   = pci_resource_flags(pdev, 0);
+              ddata->regions[0].length  = ddata->regions[0].end - ddata->regions[0].start + 1;
+
               ddata->regions[1].start   = pci_resource_start(pdev, 2);
               ddata->regions[1].end     = pci_resource_end(pdev, 2);
               ddata->regions[1].flags   = pci_resource_flags(pdev, 2);

--- a/apci_dev.c
+++ b/apci_dev.c
@@ -412,6 +412,8 @@ apci_alloc_driver(struct pci_dev *pdev, const struct pci_device_id *id )
     ddata->irq = 0;
     ddata->irq_capable = 0;
 
+    ddata->dma_virt_addr = NULL;
+
     for (count = 0; count < 6; count++) {
         ddata->regions[count].start = 0;
         ddata->regions[count].end = 0;


### PR DESCRIPTION
When removing the module it checks for the dma_virt_addr and if it
is not NULL it tries to free the dma allocation. However since
dma_virt_addr is never initialized, it holds a garbage value which
ends up causing a freeze on the system.