### PR TITLE
Update driver to compile on kernel 5.18 and 6.2

### DIFF
--- a/apci_dev.c
+++ b/apci_dev.c
@@ -1883,7 +1883,11 @@ exit_free:
 }
 
 /* Configure the default /dev/{devicename} permissions */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
 static char *apci_devnode(struct device *dev, umode_t *mode)
+#else
+static char *apci_devnode(const struct device *dev, umode_t *mode)
+#endif
 {
   if (!mode)
     return NULL;

--- a/apci_fops.c
+++ b/apci_fops.c
@@ -97,7 +97,9 @@ long  ioctl_apci(struct file *filp, unsigned int cmd, unsigned long arg)
 
         case apci_get_device_info_ioctl:
           apci_debug("entering get_device_info \n");
-          #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0))
+          #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0))
+                    status = access_ok((const void *) arg, sizeof(info_struct));
+          #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0))
                     status = access_ok( arg, sizeof(info_struct));
           #else
                     status = access_ok(VERIFY_WRITE, arg,
@@ -123,7 +125,9 @@ long  ioctl_apci(struct file *filp, unsigned int cmd, unsigned long arg)
 
 
         case apci_write_ioctl:
-          #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0))
+          #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0))
+                    status = access_ok ((const void *)arg, sizeof(iopack));
+          #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0))
                     status = access_ok (arg, sizeof(iopack));
           #else
                     status = access_ok (VERIFY_WRITE, arg, sizeof(iopack));
@@ -197,7 +201,9 @@ long  ioctl_apci(struct file *filp, unsigned int cmd, unsigned long arg)
 
 
           case apci_read_ioctl:
-               #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0))
+               #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0))
+                         status = access_ok((const void *)arg, sizeof(iopack));
+               #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0))
                          status = access_ok(arg, sizeof(iopack));
                #else
                          status = access_ok(VERIFY_WRITE, arg, sizeof(iopack));
@@ -317,7 +323,9 @@ long  ioctl_apci(struct file *filp, unsigned int cmd, unsigned long arg)
          break;
 
      case apci_set_dma_transfer_size:
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0))
+          status = access_ok((const void *)arg, sizeof(dma_buffer_settings_t));
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0))
           status = access_ok(arg, sizeof(dma_buffer_settings_t));
 #else
           status = access_ok(VERIFY_WRITE, arg, sizeof(dma_buffer_settings_t));
@@ -359,8 +367,9 @@ long  ioctl_apci(struct file *filp, unsigned int cmd, unsigned long arg)
 
      case apci_data_ready:
          apci_info("Getting data ready\n");
-
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 18, 0))
+          status = access_ok((const void *)arg, sizeof(dma_buffer_settings_t));
+#elif (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0))
           status = access_ok(arg, sizeof(dma_buffer_settings_t));
 #else
           status = access_ok(VERIFY_WRITE, arg, sizeof(dma_buffer_settings_t));


### PR DESCRIPTION
Kernel 5.18 changed access_ok to have a const void * argument instead of unsigned long addr.
Kernel 6.2 will change class->devnode to have a const first argument.

Both a trivial, "no functionality changed" changes, but break compilation.
These commits update the driver to compile and work on those kernels.

This is necessary to work on the most recent Fedora Linux (6.x based) , most recent ubuntu (5.19 based), and next version of Fedora/Ubuntu (both of which are scheduled tol be 6.2 based)

Tested on a PCIE-IIRO-8 and a PCIE-IDIO-24
