### PR TITLE
Bugfix for kernel page fault on apci_wait_irq (correct branch).

### DIFF
--- a/apci_fops.c
+++ b/apci_fops.c
@@ -261,6 +261,12 @@ long  ioctl_apci(struct file *filp, unsigned int cmd, unsigned long arg)
 
 
     case apci_wait_for_irq_ioctl:
+         if (!ddata->irq_capable)
+         {
+             apci_error("Not capable of generating IRQs.\n");
+             return -EINVAL;
+         }
+
          if (ddata->irq_disabled)
          {
              apci_error("IRQ is disabled.\n");
@@ -298,6 +304,12 @@ long  ioctl_apci(struct file *filp, unsigned int cmd, unsigned long arg)
          break;
 
     case apci_cancel_wait_ioctl:
+         if (!ddata->irq_capable)
+         {
+             apci_error("Not capable of generating IRQs.\n");
+             return -EINVAL;
+         }
+         
          if (ddata->irq_disabled)
          {
              apci_error("IRQ is disabled.\n");


### PR DESCRIPTION
Fixes a bug where a page fault occurs when a device incapable of generating IRQs gets an wait_irq ioctl.