### PR TITLE
Rh compat

### DIFF
--- a/.Module.symvers.cmd
+++ b/.Module.symvers.cmd
@@ -1,1 +1,0 @@
-cmd_/home/jhentges/dev/apci/Module.symvers := sed 's/\.ko$$/\.o/' /home/jhentges/dev/apci/modules.order | scripts/mod/modpost -m -a  -o /home/jhentges/dev/apci/Module.symvers -e -i Module.symvers   -T -

--- a/.modules.order.cmd
+++ b/.modules.order.cmd
@@ -1,1 +1,0 @@
-cmd_/home/jhentges/dev/apci/modules.order := {   echo /home/jhentges/dev/apci/apci.ko; :; } | awk '!x[$$0]++' - > /home/jhentges/dev/apci/modules.order

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,12 @@ CC		?= "gcc"
 KVERSION        ?= $(shell uname -r)
 KDIR		?= /lib/modules/$(KVERSION)/build
 
+ifneq ("$(wildcard /etc/redhat-release)","")
+CFLAGS_apci_dev.o := -DRULES_DONT_APPLY_TO_RH=1
+else
+CFLAGS_apci_dev.o := -DRULES_DONT_APPLY_TO_RH=0
+endif
+
 apci-objs :=      \
     apci_fops.o   \
 	apci_dev.o

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 obj-m += apci.o
-CC		:= "gcc"
-KVERSION        := $(shell uname -r)
-KDIR		:= /lib/modules/$(KVERSION)/build
+CC		?= "gcc"
+KVERSION        ?= $(shell uname -r)
+KDIR		?= /lib/modules/$(KVERSION)/build
 
 apci-objs :=      \
     apci_fops.o   \

--- a/apci_dev.c
+++ b/apci_dev.c
@@ -2090,10 +2090,10 @@ static int dev_mode = 0;
 module_param(dev_mode, int, 0);
 
 /* Configure the default /dev/{devicename} permissions */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 2, 0)
-static char *apci_devnode(struct device *dev, umode_t *mode)
-#else
+#if LINUX_VERSION_CODE > KERNEL_VERSION(6, 2, 0) || RULES_DONT_APPLY_TO_RH
 static char *apci_devnode(const struct device *dev, umode_t *mode)
+#else
+static char *apci_devnode(struct device *dev, umode_t *mode)
 #endif
 {
   if (!mode)
@@ -2132,10 +2132,10 @@ apci_init(void)
   }
 
   /* Create the sysfs entry for this */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
-  class_apci = class_create(THIS_MODULE, APCI_CLASS_NAME);
-#else
+#if LINUX_VERSION_CODE > KERNEL_VERSION(6, 4, 0) || RULES_DONT_APPLY_TO_RH
   class_apci = class_create(APCI_CLASS_NAME);
+#else
+  class_apci = class_create(THIS_MODULE, APCI_CLASS_NAME);
 #endif
   if (IS_ERR(ptr_err = class_apci))
     goto err;


### PR DESCRIPTION
Add checking for RH in kernel module similar to how we do in apcilib.

RH will backport breaking changes in kernel modules, and we want to be as compatible as possible.